### PR TITLE
drivers/i2c: i2c_gpio:init at POST_KERNEL

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -186,6 +186,6 @@ DEVICE_AND_API_INIT(i2c_gpio_##_num, DT_INST_LABEL(_num),		\
 	    i2c_gpio_init,						\
 	    &i2c_gpio_dev_data_##_num,					\
 	    &i2c_gpio_dev_cfg_##_num,					\
-	    PRE_KERNEL_2, CONFIG_I2C_INIT_PRIORITY, &api);
+	    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_I2C_GPIO)


### PR DESCRIPTION
This is to make the gpio-i2c initialization occur after the GPIO pin
clock initialization.

Signed-off-by: Cassini Zhuang <cassini.zhuang@hansonggroup.com>